### PR TITLE
增加autoHeightAlign自动高度校准对齐功能

### DIFF
--- a/examples/gen_demo_fonts.nim
+++ b/examples/gen_demo_fonts.nim
@@ -1,7 +1,7 @@
 import os
 import nico_font_tool
 
-const fontsDir = "fonts/"
+const fontsDir = "../fonts/"
 const outputsDir = "examples/assets/fonts"
 
 removeDir(outputsDir)
@@ -13,6 +13,7 @@ createFontSheet(
     fontFilePath = joinPath(fontsDir, "quan/quan.ttf"),
     glyphAdjustWidth = -1,
     glyphAdjustHeight = -1,
+    autoHeightAlign = true # 默认是true
 )
 createFontSheet(
     fontSize = 12,


### PR DESCRIPTION
如果该字体底部大于lineheight并且头部是空白的, 就可以自动修复成和其它字体同样的高度.  

比如  设置quan 7x7 时 俄语和其它符号是7x8的高度并且头部有空白区域, 
结果该类字体就显示不了h8的字尾, 因为高度只有7,
这个功能就是修复h8的俄语和符号去掉头部空白上移变为h7, 
变成和其它字体一样可以完美显示的7x7字体了